### PR TITLE
Typo Fix: missing .10 at end of chef_server_url for app2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,7 +43,7 @@ Vagrant::Config.run do |config|
     app2config.vm.box = "ubuntu-lucid-32"
     app2config.vm.box_url = "http://files.vagrantup.com/lucid32.box"
     app2config.vm.provision :chef_client do |chef|
-      chef.chef_server_url = "http://192.168.234:4000"
+      chef.chef_server_url = "http://192.168.234.10:4000"
       chef.validation_client_name = "chef-validator"
       chef.validation_key_path = "private/validation.pem"
     end


### PR DESCRIPTION
Hey man, small typo fix, missing .10 at the end of the chef server uri IP for app2.
