### PR TITLE
tweak to fix restart of chef-solr

### DIFF
--- a/site-cookbooks/chef-init-fix/recipes/default.rb
+++ b/site-cookbooks/chef-init-fix/recipes/default.rb
@@ -23,3 +23,8 @@
     to "#{node['languages']['ruby']['bin_dir']}/#{svc}"
   end
 end
+
+# Fix permissions on /var/run/chef so that chef launchers in /etc/init.d can write pid files.
+execute "chown chef:chef #{node["chef_client"]["run_path"]};" do
+  only_if "test -d #{node["chef_client"]["run_path"]};"
+end


### PR DESCRIPTION
if the chef vbox is halted and then restarted, chef-solr doesn't restart because the chef user doesn't have permissions to write to the solr pid file in /var/run/chef .  This tweak fixes that and allows the chef vbox to be restarted smoothly.
